### PR TITLE
Fix deselection on lightbox canvases

### DIFF
--- a/customization.js
+++ b/customization.js
@@ -244,6 +244,31 @@ const dragThreshold = 5; // pixels before a drag is recognized
     let currentTextNum = 0;
     let currentImageNum = 0;
 
+    function handleTouchStart(event) {
+        event.preventDefault();
+        const { clientX, clientY } = normalizeTouch(event);
+        event.clientX = clientX;
+        event.clientY = clientY;
+        handleMouseDown(event);
+    }
+
+    function handleTouchMove(event) {
+        event.preventDefault();
+        const { clientX, clientY } = normalizeTouch(event);
+        event.clientX = clientX;
+        event.clientY = clientY;
+        event.buttons = 1;
+        handleMouseMove(event);
+    }
+
+    function handleTouchEnd(event) {
+        event.preventDefault();
+        const { clientX, clientY } = normalizeTouch(event);
+        event.clientX = clientX;
+        event.clientY = clientY;
+        handleMouseUp(event);
+    }
+
     smallCanvas.addEventListener('mousedown', handleMouseDown);
     smallCanvas.addEventListener('mousemove', handleMouseMove);
     smallCanvas.addEventListener('mouseup', handleMouseUp);
@@ -1779,33 +1804,6 @@ function handleMouseUp(event) {
     document.removeEventListener('mouseup', handleMouseUp);
 }
 
-function handleTouchStart(event) {
-    event.preventDefault();
-    console.log("Touch event triggered: touchstart");
-    const { clientX, clientY } = normalizeTouch(event);
-    event.clientX = clientX;
-    event.clientY = clientY;
-    handleMouseDown(event);
-}
-
-function handleTouchMove(event) {
-    event.preventDefault();
-    console.log("Touch event triggered: touchmove");
-    const { clientX, clientY } = normalizeTouch(event);
-    event.clientX = clientX;
-    event.clientY = clientY;
-    event.buttons = 1;
-    handleMouseMove(event);
-}
-
-function handleTouchEnd(event) {
-    event.preventDefault();
-    console.log("Touch event triggered: touchend");
-    const { clientX, clientY } = normalizeTouch(event);
-    event.clientX = clientX;
-    event.clientY = clientY;
-    handleMouseUp(event);
-}
 
 
 function deselectAllElements() {
@@ -1832,7 +1830,7 @@ function deselectAllElements() {
 document.addEventListener('click', function(e) {
 console.log("deselect click");
   // List of IDs or classes that should not trigger deselection
-  var excludeList = ['#canvas-container', '#second-canvas-container', '#controls-container', '#image-fields-container', '#text-fields-container', '.lightbox-btn'];
+  var excludeList = ['#canvas-container', '#second-canvas-container', '#lightbox-canvas', '#second-lightbox-canvas', '#controls-container', '#image-fields-container', '#text-fields-container', '.lightbox-btn'];
 
   // Check if the clicked target is outside the excluded elements
   var isOutside = excludeList.every(function(selector) {


### PR DESCRIPTION
## Summary
- keep clicks on lightbox canvases from clearing selections

## Testing
- `node --check customization.js`


------
https://chatgpt.com/codex/tasks/task_e_68793e5542a0832597d39899829782c9